### PR TITLE
✨ feat: Add endpoint to clear 404 playlists and update database

### DIFF
--- a/src/routes/api/delete-undefined-playlists/+server.ts
+++ b/src/routes/api/delete-undefined-playlists/+server.ts
@@ -1,0 +1,15 @@
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { ytMusicController } from '$server/controllers/YtMusicController';
+import { env } from '$env/dynamic/private';
+
+export const GET: RequestHandler = async ({ url }) => {
+  const maybeKey = new URL(url).searchParams.get('key');
+
+  if (maybeKey !== env.SECRET_API_MUSC_KEY) {
+    return json({ message: 'Not found', ok: false });
+  }
+
+  await ytMusicController.clear404Playlists();
+
+  return json({ ok: true });
+};

--- a/src/server/controllers/YtMusicController.ts
+++ b/src/server/controllers/YtMusicController.ts
@@ -60,6 +60,25 @@ export class YtMusicController {
     console.info(`[synced music for ${data.length} playlists]`);
   }
 
+  async clear404Playlists() {
+    const absoluteFilePath = constructAbsoluteFileName(
+      'delete_404_playlists_input.json',
+      import.meta.url
+    );
+
+    const data = await this.playlistRepository.getPlaylistIdAndCookies();
+
+    this.fs.writeFile(absoluteFilePath, JSON.stringify(data));
+
+    const result = await this.ytMusicService.clear404Playlists(absoluteFilePath);
+
+    await this.playlistRepository.updateDeletedPlaylists(result);
+
+    await this.fs.rm(absoluteFilePath);
+
+    console.info(`[set ${result.length} playlists deleted]`);
+  }
+
   /**
    * Creates a sharable playlist from liked songs
    * @param userId - Id of a user

--- a/src/server/services/YTMusicService.ts
+++ b/src/server/services/YTMusicService.ts
@@ -88,6 +88,23 @@ export class YTMusicService extends BaseService {
     return JSON.parse(resp) as PlaylistSyncResult[];
   }
 
+  /**
+   * This function checks which ytmusic playlists were deleted
+   * So than we can update our database
+   * @param filePath - Path to a json file which contains objects like {cookie:string,id:string}[]
+   */
+  async clear404Playlists(filePath: string): Promise<string[]> {
+    const resp = await this.ytMusicApiBase<string>(
+      'clear_404_playlists.py',
+      ['--input_file', filePath],
+      'error clearing deleted playlists'
+    );
+
+    const res = JSON.parse(resp) as (string | null)[];
+
+    return res.filter((r) => r !== null) as string[];
+  }
+
   async fetchUserExportedPlaylists(userId: string) {
     const q = await this.db
       .selectFrom('playlists')

--- a/static/python-scripts/clear_404_playlists.py
+++ b/static/python-scripts/clear_404_playlists.py
@@ -1,0 +1,66 @@
+import ytmusicapi
+import json
+import argparse
+from headers import get_raw_headers
+import asyncio
+
+
+async def return_id_if_playlist_undefined(cookie, id):
+    """
+    Sync the liked music playlist with a target playlist.
+
+    :param cookie: str
+      The cookie string for authentication.
+
+    :param id: str
+        The target playlist ID.
+
+    :return: str
+    """
+
+    headers_dict = get_raw_headers(cookie)
+
+    ytmusic = ytmusicapi.YTMusic(auth=headers_dict)
+
+    try:
+        ytmusic.get_playlist(playlistId=id, limit=1)
+    except Exception as e:
+        return id
+
+
+def load_input_file(file_path):
+    """
+    Load the input file.
+
+    :param file_path: str
+      The path to the input file.
+    """
+    with open(file_path, 'r') as file:
+        data = json.load(file)
+    return data
+
+async def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--input_file', type=str)
+
+    args = parser.parse_args()
+
+    data = load_input_file(args.input_file)
+
+    tasks = [
+        return_id_if_playlist_undefined(
+            item['cookie'],
+            item['id']
+        )
+        for item in data
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    result_json = json.dumps(results)
+
+    print(result_json)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
This commit introduces a new endpoint in the server file `delete-undefined-playlists/+server.ts` that handles the clearing of 404 playlists. It includes:
- Import statements for necessary modules
- Definition of a GET RequestHandler to clear 404 playlists based on a key
- Invocation of `clear404Playlists` method in `ytMusicController` to handle actual deletion logic
- Logging information about the number of playlists deleted

Additionally, this commit incorporates changes in `YtMusicController.ts`, `PlaylistsRepository.ts`, and `YTMusicService.ts` to support the clearing of 404 playlists and updating related data in the database. It also adds a Python script `clear_404_playlists.py` under `static/python-scripts` to facilitate the identification of deleted playlists within the YTMusic service.